### PR TITLE
#2 [PROD] redirect 302 si l'url contient l'âge

### DIFF
--- a/etc/caddy/Caddyfile
+++ b/etc/caddy/Caddyfile
@@ -121,6 +121,11 @@ vitemadosedevaccin.fr {
 }
 
 vitemadose.covidtracker.fr {
+	@atest {
+		path_regexp test ^(\/.*\/)age-plus75ans\/$
+	}
+	redir @atest {http.regexp.test.1} 301
+
 	root * /var/www/vitemadose.covidtracker.fr
 	encode zstd gzip
 	file_server browse

--- a/etc/caddy/Caddyfile
+++ b/etc/caddy/Caddyfile
@@ -124,7 +124,7 @@ vitemadose.covidtracker.fr {
 	@age_matcher {
 		path_regexp age ^(\/.*\/)age-plus75ans\/$
 	}
-	redir @age_matcher {http.regexp.age.1} 301
+	redir @age_matcher {http.regexp.age.1}
 
 	root * /var/www/vitemadose.covidtracker.fr
 	encode zstd gzip

--- a/etc/caddy/Caddyfile
+++ b/etc/caddy/Caddyfile
@@ -121,10 +121,10 @@ vitemadosedevaccin.fr {
 }
 
 vitemadose.covidtracker.fr {
-	@atest {
-		path_regexp test ^(\/.*\/)age-plus75ans\/$
+	@age_matcher {
+		path_regexp age ^(\/.*\/)age-plus75ans\/$
 	}
-	redir @atest {http.regexp.test.1} 301
+	redir @age_matcher {http.regexp.age.1} 301
 
 	root * /var/www/vitemadose.covidtracker.fr
 	encode zstd gzip


### PR DESCRIPTION
Fix #2 

Lié à PR https://github.com/CovidTrackerFr/vitemadose-front/pull/70 qui est validée sur le principe (cf: https://github.com/CovidTrackerFr/vitemadose-front/issues/69#issuecomment-819141959)

Si le changement est ok, il faut attendre avant de merger. Ce changement doit être déployé seulement une fois que le changement de la PR https://github.com/CovidTrackerFr/vitemadose-front/pull/70 est déployé en production, si possible le moins de temps possible après.