### PR TITLE
#2 [DEV] Redirect 302 si l'url contient l'âge

### DIFF
--- a/etc/caddy/Caddyfile
+++ b/etc/caddy/Caddyfile
@@ -135,7 +135,7 @@ dev.vitemado.se {
 	@age_matcher {
 		path_regexp age ^(\/.*\/)age-plus75ans\/$
 	}
-	redir @age_matcher {http.regexp.age.1} 301
+	redir @age_matcher {http.regexp.age.1}
 
  	root * /var/www/dev.vitemado.se
  	encode zstd gzip

--- a/etc/caddy/Caddyfile
+++ b/etc/caddy/Caddyfile
@@ -132,6 +132,11 @@ vitemadose.covidtracker.fr {
 }
 
 dev.vitemado.se {
+	@age_matcher {
+		path_regexp age ^(\/.*\/)age-plus75ans\/$
+	}
+	redir @age_matcher {http.regexp.age.1} 301
+
  	root * /var/www/dev.vitemado.se
  	encode zstd gzip
  	file_server browse


### PR DESCRIPTION
Relates #2, #3 

Lié à PR CovidTrackerFr/vitemadose-front#70 qui est validée sur le principe (cf: CovidTrackerFr/vitemadose-front#69 (comment))

Si le changement est ok, il faut attendre avant de merger. Ce changement doit être déployé seulement une fois que le changement de la PR CovidTrackerFr/vitemadose-front#70 est déployé en production, si possible le moins de temps possible après.