### PR TITLE
try_files pour dev.vitemado.se

### DIFF
--- a/etc/caddy/Caddyfile
+++ b/etc/caddy/Caddyfile
@@ -140,7 +140,8 @@ dev.vitemado.se {
 	import static 0
  	import security
  	header Access-Control-Allow-Origin https://vitemadose.covidtracker.fr
- 	try_files {path} {path}/ /index.html
+	@subdirs path_regexp subdir_regex ^/([^/]+)/(.*)$
+ 	try_files @subdirs /{re.path_regexp.1}/index.html {path} {path}/ /index.html
  }
 
 


### PR DESCRIPTION
L'idée est de faire servir https://dev.vitemado.se/xxx/index.html lorsqu'on tape sur une URL du type https://dev.vitemado.se/xxx/yyy/zzz

Je vais avoir besoin de faire fonctionner ces URLs pour pouvoir tester les notifications PUSH déployées ici : https://dev.vitemado.se/push-notifs/ (URL du type https://dev.vitemado.se/push-notifs/centres-vaccination-covid-dpt33-gironde/commune33550-33140-villenave_d_ornon/en-triant-par-distance)

⚠️ Je n'ai pas du tout testé ce que j'ai fait, je me suis uniquement basé sur ce que j'ai trouvé ici et là sur internet, notamment https://caddy.community/t/v2-help-with-path-regexp-and-rewrite/9442/10