### PR TITLE
Fix #190 with correct SEO redirect code for google

### DIFF
--- a/etc/caddy/Caddyfile
+++ b/etc/caddy/Caddyfile
@@ -69,7 +69,7 @@ www.covidtracker.fr {
 }
 
 covidtracker.fr {
-	redir /vitemadose* https://vitemadose.covidtracker.fr
+	redir /vitemadose* https://vitemadose.covidtracker.fr 301
 	
 	root * /var/www/covidtracker.fr
 	encode zstd gzip


### PR DESCRIPTION
This PR is for issus https://github.com/CovidTrackerFr/vitemadose-front/issues/190.
It change redirect code status by default in 302 with CaddyFile by 301 Permanent redirect.

Doc => https://caddyserver.com/docs/caddyfile/directives/redir